### PR TITLE
Add license name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+The MIT License (MIT)
+
 Copyright (c) 2014 Pascal Hartig
 
 Permission is hereby granted, free of charge, to any person


### PR DESCRIPTION
Noone know licenses by text :). Of cource, there is license name in bottom of `README.md` and `package.json`, but it is very naturally to go to `LICENSE` first.
