### PR TITLE
Remove another comma separated syntax for browsers

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Or within the webpack config:
 module: {
   loaders: [{
     test: /\.css$/,
-    loader: 'css-loader!autoprefixer-loader?browsers=last 2 version, Firefox 15'
+    loader: 'css-loader!autoprefixer-loader?browsers=last 2 version'
   }]
 }
 ```


### PR DESCRIPTION
Found another one. Your docs are nice. So if you want to fix it differently, then feel free to close this.
