### PR TITLE
Update existing sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var loaderUtils = require('loader-utils');
 var autoprefixer = require('autoprefixer-core');
 
-module.exports = function (source) {
+module.exports = function (source, map) {
     if (this.cacheable) {
         this.cacheable();
     }
@@ -37,6 +37,12 @@ module.exports = function (source) {
             'Autoprefixer-loader got these undocumented options: ';
         warn += unknownParams.join(', ');
         this.emitWarning(warn);
+    }
+
+    if(map) {
+        options.map = {
+            prev: map
+        }
     }
 
     var processed = autoprefixer(params).process(source, options);

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ module.exports = function (source, map) {
     if(map) {
         options.map = {
             prev: map
-        }
+        };
     }
 
     var processed = autoprefixer(params).process(source, options);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 var loaderUtils = require('loader-utils');
 var autoprefixer = require('autoprefixer-core');
+var path = require('path');
 
 module.exports = function (source, map) {
     if (this.cacheable) {
@@ -16,7 +17,7 @@ module.exports = function (source, map) {
         params.cascade = false;
     }
 
-    var options = { from: file };
+    var options = { from: path.relative(this.options.context, this.resource) };
     if (params.safe) {
         delete params.safe;
         options.safe = true;


### PR DESCRIPTION
Update existing sourcemaps from previous webpack loaders in the chain.
See https://github.com/3sv/webpack-less-autoprefixer-sourcemaps-demo for  a demo with less.

Not sure if the changed 'from' path will cause problems for some use cases. Changed this to have proper filenames in the source-maps. If this causes problems the shorter filenames should only be used on the map. 