### PR TITLE
Add 'build/**' to xo ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,10 @@
         2,
         "always-multiline"
       ]
-    }
+    },
+    "ignores": [
+      "build/**"
+    ]
   },
   "scripts": {
     "test": "xo && gulp"


### PR DESCRIPTION
Previously when running `npm test` multiple times in a row, the
`build/test.js` file would cause warnings from eslint/xo. This patch makes
xo ignore that directory.