### PR TITLE
Move away from deprecated autoprefixer-core

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var loaderUtils = require('loader-utils');
-var autoprefixerCore = require('autoprefixer-core');
+var autoprefixer = require('autoprefixer');
 var postcss = require('postcss');
 var path = require('path');
 var safe = require('postcss-safe-parser');
@@ -50,7 +50,7 @@ module.exports = function (source, map) {
         };
     }
 
-    var autoprefixer = autoprefixerCore(params);
-    var processed = postcss([autoprefixer]).process(source, options);
+    var prefixer = autoprefixer(params);
+    var processed = postcss([prefixer]).process(source, options);
     this.callback(null, processed.css, processed.map);
 };

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/passy/autoprefixer-loader/issues"
   },
   "dependencies": {
-    "autoprefixer-core": "^6.0.1",
+    "autoprefixer": "^6.0.2",
     "loader-utils": "^0.2.11",
     "postcss": "^5.0.4",
     "postcss-safe-parser": "^1.0.1"


### PR DESCRIPTION
There was a deprecation warning indicating that autoprefixer-core
had been moved into autoprefixer proper. This patch migrates the
package over to use autoprefixer.

See https://www.npmjs.com/package/autoprefixer-core