### PR TITLE
Update package to renamed webpack-stream

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,7 +8,7 @@ gulp.task('clean', function (done) {
 });
 
 gulp.task('build', ['clean'], function () {
-    var webpack = require('gulp-webpack');
+    var webpack = require('webpack-stream');
 
     return gulp.src('')
         .pipe(webpack({

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "fs-extra": "^0.24.0",
     "gulp": "^3.9.0",
     "gulp-mocha": "^2.1.3",
-    "gulp-webpack": "^1.5.0",
     "raw-loader": "^0.5.1",
     "should": "^7.1.0",
+    "webpack-stream": "^2.1.0",
     "xo": "^0.8.0"
   },
   "keywords": [


### PR DESCRIPTION
gulp-webpack had been renamed to webpack-stream. This patch moves
the package over to the new webpack-stream.

See https://github.com/shama/webpack-stream#release-history