### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "autoprefixer": "^6.0.2",
-    "loader-utils": "^0.2.11",
+    "loader-utils": "^1.1.0",
     "postcss": "^5.0.4",
     "postcss-safe-parser": "^1.0.1"
   },


### PR DESCRIPTION
(node:66000) DeprecationWarning: loaderUtils.parseQuery() received a non-string value which can be problematic, see https://github.com/webpack/loader-utils/issues/56
parseQuery() will be replaced with getOptions() in the next major version of loader-utils.